### PR TITLE
Remove filesystem timestamps from ExifTool priority list

### DIFF
--- a/date-renamer-toolkit.py
+++ b/date-renamer-toolkit.py
@@ -165,8 +165,6 @@ EXIFTOOL_DATE_TAGS = [
     "QuickTime:TrackCreateDate",
     "QuickTime:ModifyDate",
     "QuickTime:ContentCreateDate",
-    "File:FileModifyDate",
-    "File:FileCreateDate",
     "Composite:SubSecDateTimeOriginal",
     "Composite:DateTimeCreated",
     "PNG:CreationTime",


### PR DESCRIPTION
### Motivation
- Filesystem-derived ExifTool tags (`File:FileModifyDate`, `File:FileCreateDate`) were being treated as prioritized metadata, which allowed filesystem timestamps to bypass the "Fallback if missing = OFF" behavior.

### Description
- Remove `File:FileModifyDate` and `File:FileCreateDate` from `EXIFTOOL_DATE_TAGS` in `date-renamer-toolkit.py` so filesystem timestamps are no longer provided by ExifTool priority and the existing fallback logic regains control.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697605720cd8832ba3780e7e7c890750)